### PR TITLE
chore: print the current size of the allure report repo in the workflow summary

### DIFF
--- a/.github/workflows/playwright-mysite.yml
+++ b/.github/workflows/playwright-mysite.yml
@@ -174,11 +174,9 @@ jobs:
           # concerned about it much.
 
       - name: Check Allure repository size
-        id: repo_size
         run: |
           size=$(curl -s "https://api.github.com/repos/readytotest/playwright-allure-report" | jq -r '.size')
           size_gb=$(echo "scale=3; $size / 1024 / 1024" | bc)
-          echo "repo_size=${size_gb} GB" >> $GITHUB_ENV
           echo "playwright-allure-report repo size: ${size_gb} GB"
 
       # https://tools.slack.dev/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/

--- a/.github/workflows/playwright-mysite.yml
+++ b/.github/workflows/playwright-mysite.yml
@@ -173,6 +173,14 @@ jobs:
           # the git history to keep that repo size down.... all that repo is for is those reports anyway, so im not
           # concerned about it much.
 
+      - name: Check Allure repository size
+        id: repo_size
+        run: |
+          size=$(curl -s "https://api.github.com/repos/readytotest/playwright-allure-report" | jq -r '.size')
+          size_gb=$(echo "scale=3; $size / 1024 / 1024" | bc)
+          echo "repo_size=${size_gb} GB" >> $GITHUB_ENV
+          echo "playwright-allure-report repo size: ${size_gb} GB"
+
       # https://tools.slack.dev/slack-github-action/sending-techniques/sending-data-slack-incoming-webhook/
       - name: Send to Slack channel
         if: always()

--- a/.github/workflows/playwright-mysite.yml
+++ b/.github/workflows/playwright-mysite.yml
@@ -173,6 +173,10 @@ jobs:
           # the git history to keep that repo size down.... all that repo is for is those reports anyway, so im not
           # concerned about it much.
 
+      # Curl gets the repo info from GitHub, then jq filters out just the size.
+      # It's converted from KB to GB using basic calculator
+      # Scale is set to 3 decimal places
+      # This is to keep tabs on the Allure repo size
       - name: Check Allure repository size
         run: |
           size=$(curl -s "https://api.github.com/repos/readytotest/playwright-allure-report" | jq -r '.size')


### PR DESCRIPTION
Add a step in the YAML in the main repo to keep tabs on the allure repo size.